### PR TITLE
add batch and redis hash helper methods (#3, #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.3.19] - 2026-03-31
+
+### Added
+- `cache_mget` / `cache_mset` (and `local_cache_mget` / `local_cache_mset`) on `Helper` mixin — delegates to Redis batch ops, falls back to sequential get/set on Memcached (closes #3)
+- `cache_hset`, `cache_hgetall`, `cache_hdel`, `cache_zadd`, `cache_zrangebyscore`, `cache_zrem`, `cache_expire` on `Helper` mixin — delegates to `RedisHash` with namespace prefixing; hash ops fall back to JSON-serialized Memcached values, sorted-set ops raise `NotImplementedError`, expire is a no-op on Memcached (closes #4)
+
 ## [1.3.18] - 2026-03-29
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ group :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
   gem 'rubocop'
+  gem 'rubocop-legion'
   gem 'simplecov'
 end

--- a/lib/legion/cache/helper.rb
+++ b/lib/legion/cache/helper.rb
@@ -54,6 +54,162 @@ module Legion
         !Legion::Cache.get(cache_namespace + key).nil?
       end
 
+      # --- Batch Operations (shared tier) ---
+      # Issue #3: mget/mset with Memcached safety
+
+      # Returns a Hash of { key => value } pairs. Prefixes all keys with cache_namespace.
+      # Delegates to Legion::Cache.mget on Redis; falls back to sequential gets on Memcached.
+      def cache_mget(*keys)
+        keys = keys.flatten
+        return {} if keys.empty?
+
+        namespaced = keys.map { |k| cache_namespace + k }
+
+        if cache_redis?
+          raw = Legion::Cache.mget(*namespaced)
+          keys.to_h { |k| [k, raw[cache_namespace + k]] }
+        else
+          keys.to_h { |k| [k, Legion::Cache.get(cache_namespace + k)] }
+        end
+      rescue StandardError => e
+        log_cache_error('cache_mget', e)
+        {}
+      end
+
+      # Stores multiple key-value pairs. Accepts a Hash of { key => value }.
+      # TTL follows the same resolution chain as cache_set.
+      # Delegates to Legion::Cache.mset on Redis; falls back to sequential sets on Memcached.
+      def cache_mset(hash, ttl: nil)
+        return true if hash.empty?
+
+        effective_ttl = ttl || cache_default_ttl
+
+        if cache_redis?
+          namespaced = hash.transform_keys { |k| cache_namespace + k }
+          Legion::Cache.mset(namespaced)
+        else
+          hash.each { |k, v| Legion::Cache.set(cache_namespace + k, v, effective_ttl) }
+          true
+        end
+      rescue StandardError => e
+        log_cache_error('cache_mset', e)
+        false
+      end
+
+      # --- Batch Operations (local tier) ---
+
+      def local_cache_mget(*keys)
+        keys = keys.flatten
+        return {} if keys.empty?
+
+        if local_cache_redis?
+          namespaced = keys.map { |k| cache_namespace + k }
+          raw = Legion::Cache::Local.mget(*namespaced)
+          keys.to_h { |k| [k, raw[cache_namespace + k]] }
+        else
+          keys.to_h { |k| [k, Legion::Cache::Local.get(cache_namespace + k)] }
+        end
+      rescue StandardError => e
+        log_cache_error('local_cache_mget', e)
+        {}
+      end
+
+      def local_cache_mset(hash, ttl: nil)
+        return true if hash.empty?
+
+        effective_ttl = ttl || local_cache_default_ttl
+
+        if local_cache_redis?
+          namespaced = hash.transform_keys { |k| cache_namespace + k }
+          Legion::Cache::Local.mset(namespaced)
+        else
+          hash.each { |k, v| Legion::Cache::Local.set(cache_namespace + k, v, effective_ttl) }
+          true
+        end
+      rescue StandardError => e
+        log_cache_error('local_cache_mset', e)
+        false
+      end
+
+      # --- RedisHash Helpers (shared tier) ---
+      # Issue #4: namespaced wrappers for RedisHash operations with Memcached fallback
+
+      def cache_hset(key, hash)
+        if cache_redis?
+          Legion::Cache::RedisHash.hset(cache_namespace + key, hash)
+        else
+          memcached_hash_merge(cache_namespace + key, hash)
+        end
+      rescue StandardError => e
+        log_cache_error('cache_hset', e)
+        false
+      end
+
+      def cache_hgetall(key)
+        if cache_redis?
+          Legion::Cache::RedisHash.hgetall(cache_namespace + key)
+        else
+          memcached_hash_load(cache_namespace + key)
+        end
+      rescue StandardError => e
+        log_cache_error('cache_hgetall', e)
+        nil
+      end
+
+      def cache_hdel(key, *fields)
+        if cache_redis?
+          Legion::Cache::RedisHash.hdel(cache_namespace + key, *fields)
+        else
+          memcached_hash_delete_fields(cache_namespace + key, fields)
+        end
+      rescue StandardError => e
+        log_cache_error('cache_hdel', e)
+        0
+      end
+
+      def cache_zadd(key, score, member)
+        raise_sorted_set_unsupported('cache_zadd') unless cache_redis?
+
+        Legion::Cache::RedisHash.zadd(cache_namespace + key, score, member)
+      rescue NotImplementedError
+        raise
+      rescue StandardError => e
+        log_cache_error('cache_zadd', e)
+        false
+      end
+
+      def cache_zrangebyscore(key, min, max, limit: nil)
+        raise_sorted_set_unsupported('cache_zrangebyscore') unless cache_redis?
+
+        Legion::Cache::RedisHash.zrangebyscore(cache_namespace + key, min, max, limit: limit)
+      rescue NotImplementedError
+        raise
+      rescue StandardError => e
+        log_cache_error('cache_zrangebyscore', e)
+        []
+      end
+
+      def cache_zrem(key, member)
+        raise_sorted_set_unsupported('cache_zrem') unless cache_redis?
+
+        Legion::Cache::RedisHash.zrem(cache_namespace + key, member)
+      rescue NotImplementedError
+        raise
+      rescue StandardError => e
+        log_cache_error('cache_zrem', e)
+        false
+      end
+
+      # Sets TTL on a key. No-op on Memcached (TTL is set at write time).
+      def cache_expire(key, seconds)
+        return false unless cache_redis?
+
+        Legion::Cache::RedisHash.expire(cache_namespace + key, seconds)
+      rescue StandardError => e
+        log_cache_error('cache_expire', e)
+        false
+      end
+
       # --- Core Operations (local tier) ---
 
       def local_cache_set(key, value, ttl: nil, phi: false)
@@ -146,6 +302,56 @@ module Legion
         target.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
               .gsub(/([a-z\d])([A-Z])/, '\1_\2')
               .downcase
+      end
+
+      def cache_redis?
+        Legion::Cache::RedisHash.redis_available?
+      end
+
+      def local_cache_redis?
+        defined?(Legion::Cache::Local) &&
+          Legion::Cache::Local.respond_to?(:mget) &&
+          Legion::Cache::Local.connected?
+      end
+
+      def memcached_hash_merge(full_key, new_fields)
+        current = memcached_hash_load(full_key) || {}
+        merged = current.merge(new_fields.transform_keys(&:to_s))
+        Legion::Cache.set(full_key, Legion::JSON.dump(merged), cache_default_ttl)
+        true
+      end
+
+      def memcached_hash_load(full_key)
+        raw = Legion::Cache.get(full_key)
+        return nil if raw.nil?
+
+        parsed = Legion::JSON.load(raw)
+        # Legion::JSON.load returns symbol keys; convert to string keys to mirror Redis hgetall
+        parsed.transform_keys(&:to_s)
+      rescue StandardError
+        nil
+      end
+
+      def memcached_hash_delete_fields(full_key, fields)
+        current = memcached_hash_load(full_key)
+        return 0 if current.nil?
+
+        str_fields = fields.map(&:to_s)
+        removed = str_fields.count { |f| current.key?(f) }
+        str_fields.each { |f| current.delete(f) }
+        Legion::Cache.set(full_key, Legion::JSON.dump(current), cache_default_ttl)
+        removed
+      end
+
+      def raise_sorted_set_unsupported(method)
+        raise NotImplementedError,
+              "#{method} requires a Redis backend — sorted sets are not supported on Memcached"
+      end
+
+      def log_cache_error(method, error)
+        return unless defined?(Legion::Logging)
+
+        Legion::Logging.warn "[cache:helper] #{method} failed: #{error.class} — #{error.message}"
       end
     end
   end

--- a/lib/legion/cache/version.rb
+++ b/lib/legion/cache/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Cache
-    VERSION = '1.3.18'
+    VERSION = '1.3.19'
   end
 end

--- a/spec/legion/cache/helper_spec.rb
+++ b/spec/legion/cache/helper_spec.rb
@@ -269,4 +269,332 @@ RSpec.describe Legion::Cache::Helper do
       expect(subject.local_cache_pool_available).to eq(0)
     end
   end
+
+  # --- Issue #3: cache_mget / cache_mset ---
+
+  describe '#cache_mget' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to Legion::Cache.mget with namespaced keys and un-namespaces the result' do
+        allow(Legion::Cache).to receive(:mget).with('microsoft_teams:a', 'microsoft_teams:b')
+                                              .and_return({ 'microsoft_teams:a' => 'v1', 'microsoft_teams:b' => 'v2' })
+        expect(subject.cache_mget(':a', ':b')).to eq({ ':a' => 'v1', ':b' => 'v2' })
+      end
+
+      it 'returns empty hash for empty key list' do
+        expect(subject.cache_mget).to eq({})
+      end
+
+      it 'returns empty hash on error' do
+        allow(Legion::Cache).to receive(:mget).and_raise(StandardError, 'fail')
+        expect(subject.cache_mget(':x')).to eq({})
+      end
+    end
+
+    context 'with Memcached backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'falls back to sequential gets and un-namespaces keys' do
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:a').and_return('v1')
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:b').and_return('v2')
+        expect(subject.cache_mget(':a', ':b')).to eq({ ':a' => 'v1', ':b' => 'v2' })
+      end
+
+      it 'accepts an array argument' do
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:x').and_return('vx')
+        expect(subject.cache_mget([':x'])).to eq({ ':x' => 'vx' })
+      end
+    end
+  end
+
+  describe '#cache_mset' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to Legion::Cache.mset with namespaced keys' do
+        expect(Legion::Cache).to receive(:mset).with({ 'microsoft_teams:a' => 'v1', 'microsoft_teams:b' => 'v2' })
+        subject.cache_mset({ ':a' => 'v1', ':b' => 'v2' })
+      end
+
+      it 'returns true for empty hash without calling mset' do
+        expect(Legion::Cache).not_to receive(:mset)
+        expect(subject.cache_mset({})).to be true
+      end
+
+      it 'returns false on error' do
+        allow(Legion::Cache).to receive(:mset).and_raise(StandardError, 'fail')
+        expect(subject.cache_mset({ ':x' => 'v' })).to be false
+      end
+    end
+
+    context 'with Memcached backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'falls back to sequential sets using default TTL' do
+        expect(Legion::Cache).to receive(:set).with('microsoft_teams:a', 'v1', 60)
+        expect(Legion::Cache).to receive(:set).with('microsoft_teams:b', 'v2', 60)
+        subject.cache_mset({ ':a' => 'v1', ':b' => 'v2' })
+      end
+
+      it 'uses explicit TTL when provided' do
+        expect(Legion::Cache).to receive(:set).with('microsoft_teams:k', 'val', 300)
+        subject.cache_mset({ ':k' => 'val' }, ttl: 300)
+      end
+
+      it 'returns true on success' do
+        allow(Legion::Cache).to receive(:set)
+        expect(subject.cache_mset({ ':k' => 'v' })).to be true
+      end
+    end
+  end
+
+  describe '#local_cache_mget' do
+    context 'with Redis local backend' do
+      before do
+        allow(subject).to receive(:local_cache_redis?).and_return(true)
+        allow(Legion::Cache::Local).to receive(:mget).with('microsoft_teams:a')
+                                                     .and_return({ 'microsoft_teams:a' => 'lv1' })
+      end
+
+      it 'delegates to Legion::Cache::Local.mget and un-namespaces keys' do
+        expect(subject.local_cache_mget(':a')).to eq({ ':a' => 'lv1' })
+      end
+    end
+
+    context 'with Memcached local backend' do
+      before { allow(subject).to receive(:local_cache_redis?).and_return(false) }
+
+      it 'falls back to sequential local gets' do
+        allow(Legion::Cache::Local).to receive(:get).with('microsoft_teams:a').and_return('lv1')
+        expect(subject.local_cache_mget(':a')).to eq({ ':a' => 'lv1' })
+      end
+    end
+
+    it 'returns empty hash for empty key list' do
+      expect(subject.local_cache_mget).to eq({})
+    end
+  end
+
+  describe '#local_cache_mset' do
+    context 'with Redis local backend' do
+      before { allow(subject).to receive(:local_cache_redis?).and_return(true) }
+
+      it 'delegates to Legion::Cache::Local.mset with namespaced keys' do
+        expect(Legion::Cache::Local).to receive(:mset).with({ 'microsoft_teams:k' => 'v' })
+        subject.local_cache_mset({ ':k' => 'v' })
+      end
+    end
+
+    context 'with Memcached local backend' do
+      before { allow(subject).to receive(:local_cache_redis?).and_return(false) }
+
+      it 'falls back to sequential local sets' do
+        expect(Legion::Cache::Local).to receive(:set).with('microsoft_teams:k', 'v', 60)
+        subject.local_cache_mset({ ':k' => 'v' })
+      end
+
+      it 'uses explicit TTL when provided' do
+        expect(Legion::Cache::Local).to receive(:set).with('microsoft_teams:k', 'v', 120)
+        subject.local_cache_mset({ ':k' => 'v' }, ttl: 120)
+      end
+    end
+
+    it 'returns true for empty hash' do
+      expect(subject.local_cache_mset({})).to be true
+    end
+  end
+
+  # --- Issue #4: RedisHash helper methods ---
+
+  describe '#cache_hset' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to RedisHash.hset with namespaced key' do
+        expect(Legion::Cache::RedisHash).to receive(:hset).with('microsoft_teams:h', { 'f' => 'v' }).and_return(true)
+        expect(subject.cache_hset(':h', { 'f' => 'v' })).to be true
+      end
+
+      it 'returns false on error' do
+        allow(Legion::Cache::RedisHash).to receive(:hset).and_raise(StandardError, 'fail')
+        expect(subject.cache_hset(':h', {})).to be false
+      end
+    end
+
+    context 'with Memcached backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'serializes hash as JSON via cache set (merge)' do
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:h').and_return(nil)
+        expect(Legion::Cache).to receive(:set).with('microsoft_teams:h', '{"f":"v"}', 60)
+        subject.cache_hset(':h', { 'f' => 'v' })
+      end
+
+      it 'merges new fields into existing JSON hash' do
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:h').and_return('{"existing":"val"}')
+        expect(Legion::Cache).to receive(:set) do |_key, json, _ttl|
+          parsed = Legion::JSON.load(json)
+          expect(parsed).to include(existing: 'val', f: 'v')
+        end
+        subject.cache_hset(':h', { 'f' => 'v' })
+      end
+    end
+  end
+
+  describe '#cache_hgetall' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to RedisHash.hgetall with namespaced key' do
+        expect(Legion::Cache::RedisHash).to receive(:hgetall).with('microsoft_teams:h').and_return({ 'f' => 'v' })
+        expect(subject.cache_hgetall(':h')).to eq({ 'f' => 'v' })
+      end
+
+      it 'returns nil on error' do
+        allow(Legion::Cache::RedisHash).to receive(:hgetall).and_raise(StandardError, 'fail')
+        expect(subject.cache_hgetall(':h')).to be_nil
+      end
+    end
+
+    context 'with Memcached backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'deserializes JSON from cache and returns string-key hash' do
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:h').and_return('{"f":"v"}')
+        result = subject.cache_hgetall(':h')
+        expect(result).to eq({ 'f' => 'v' })
+      end
+
+      it 'returns nil when key is absent' do
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:h').and_return(nil)
+        expect(subject.cache_hgetall(':h')).to be_nil
+      end
+    end
+  end
+
+  describe '#cache_hdel' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to RedisHash.hdel with namespaced key' do
+        expect(Legion::Cache::RedisHash).to receive(:hdel).with('microsoft_teams:h', 'f1').and_return(1)
+        expect(subject.cache_hdel(':h', 'f1')).to eq(1)
+      end
+
+      it 'returns 0 on error' do
+        allow(Legion::Cache::RedisHash).to receive(:hdel).and_raise(StandardError, 'fail')
+        expect(subject.cache_hdel(':h', 'f')).to eq(0)
+      end
+    end
+
+    context 'with Memcached backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'removes specified fields from JSON hash and returns count' do
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:h').and_return('{"a":"1","b":"2"}')
+        expect(Legion::Cache).to receive(:set).with('microsoft_teams:h', anything, 60) do |_k, json, _ttl|
+          parsed = Legion::JSON.load(json)
+          expect(parsed.keys.map(&:to_s)).not_to include('a')
+        end
+        expect(subject.cache_hdel(':h', 'a')).to eq(1)
+      end
+
+      it 'returns 0 when key is absent' do
+        allow(Legion::Cache).to receive(:get).with('microsoft_teams:h').and_return(nil)
+        expect(subject.cache_hdel(':h', 'f')).to eq(0)
+      end
+    end
+  end
+
+  describe '#cache_zadd' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to RedisHash.zadd with namespaced key' do
+        expect(Legion::Cache::RedisHash).to receive(:zadd).with('microsoft_teams:z', 1.5, 'member').and_return(true)
+        expect(subject.cache_zadd(':z', 1.5, 'member')).to be true
+      end
+    end
+
+    context 'with Memcached backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'raises NotImplementedError' do
+        expect { subject.cache_zadd(':z', 1.0, 'm') }.to raise_error(NotImplementedError, /cache_zadd/)
+      end
+    end
+  end
+
+  describe '#cache_zrangebyscore' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to RedisHash.zrangebyscore with namespaced key' do
+        expect(Legion::Cache::RedisHash).to receive(:zrangebyscore)
+          .with('microsoft_teams:z', 0, 100, limit: nil)
+          .and_return(%w[a b])
+        expect(subject.cache_zrangebyscore(':z', 0, 100)).to eq(%w[a b])
+      end
+
+      it 'passes limit option' do
+        expect(Legion::Cache::RedisHash).to receive(:zrangebyscore)
+          .with('microsoft_teams:z', 0, 100, limit: [0, 5])
+          .and_return(['a'])
+        expect(subject.cache_zrangebyscore(':z', 0, 100, limit: [0, 5])).to eq(['a'])
+      end
+    end
+
+    context 'with Memcached backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'raises NotImplementedError' do
+        expect { subject.cache_zrangebyscore(':z', 0, 100) }.to raise_error(NotImplementedError, /cache_zrangebyscore/)
+      end
+    end
+  end
+
+  describe '#cache_zrem' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to RedisHash.zrem with namespaced key' do
+        expect(Legion::Cache::RedisHash).to receive(:zrem).with('microsoft_teams:z', 'm').and_return(true)
+        expect(subject.cache_zrem(':z', 'm')).to be true
+      end
+    end
+
+    context 'with Memcached backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'raises NotImplementedError' do
+        expect { subject.cache_zrem(':z', 'm') }.to raise_error(NotImplementedError, /cache_zrem/)
+      end
+    end
+  end
+
+  describe '#cache_expire' do
+    context 'with Redis backend' do
+      before { allow(subject).to receive(:cache_redis?).and_return(true) }
+
+      it 'delegates to RedisHash.expire with namespaced key' do
+        expect(Legion::Cache::RedisHash).to receive(:expire).with('microsoft_teams:k', 300).and_return(true)
+        expect(subject.cache_expire(':k', 300)).to be true
+      end
+
+      it 'returns false on error' do
+        allow(Legion::Cache::RedisHash).to receive(:expire).and_raise(StandardError, 'fail')
+        expect(subject.cache_expire(':k', 60)).to be false
+      end
+    end
+
+    context 'with Memcached backend (no-op)' do
+      before { allow(subject).to receive(:cache_redis?).and_return(false) }
+
+      it 'returns false without calling RedisHash' do
+        expect(Legion::Cache::RedisHash).not_to receive(:expire)
+        expect(subject.cache_expire(':k', 300)).to be false
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ Legion::Logging.setup(log_file: './legion.log')
 require 'legion/cache/settings'
 require 'legion/cache/version'
 require 'legion/cache/local'
+require 'legion/cache/redis_hash'
 require 'legion/cache/helper'
 
 Legion::Settings.merge_settings('cache', Legion::Cache::Settings.default)


### PR DESCRIPTION
## Summary
- **#3**: Add `cache_mget`/`cache_mset` (and local variants) to Helper mixin — delegates to Redis batch ops, falls back to sequential on Memcached
- **#4**: Add `cache_hset`/`cache_hgetall`/`cache_hdel`/`cache_zadd`/`cache_zrangebyscore`/`cache_zrem`/`cache_expire` to Helper mixin — delegates to RedisHash with Memcached JSON-serialized fallback for hash ops, NotImplementedError for sorted sets

Closes #3, closes #4

## Test Coverage
- Specs for batch ops with Redis and Memcached fallback
- Specs for RedisHash helpers with namespace prefixing
- Specs for Memcached degradation (hash → JSON, sorted set → NotImplementedError)
- `bundle exec rspec` — all passing
- `bundle exec rubocop` — zero offenses