### PR TITLE
fix redis timeout and reconnect not forwarded to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.3.20] - 2026-03-31
+
+### Fixed
+- Forward `timeout` setting to `::Redis.new` — was silently using redis gem's 1.0s default instead of configured 5s, causing spurious timeouts on service mesh connections
+- Forward `timeout` to `::Redis.new` in cluster mode path as well
+
+### Changed
+- Increase `reconnect_attempts` from `1` to `[0, 0.5, 1]` (shared) / `[0, 0.25, 0.5]` (local) — 3 retries with escalating backoff instead of 1 instant retry, improving resilience for service mesh and remote Redis connections
+
 ## [1.3.19] - 2026-03-31
 
 ### Added

--- a/lib/legion/cache/redis.rb
+++ b/lib/legion/cache/redis.rb
@@ -12,7 +12,7 @@ module Legion
       extend self
 
       def client(pool_size: 20, timeout: 5, server: nil, servers: [], cluster: nil, replica: false, # rubocop:disable Metrics/ParameterLists
-                 fixed_hostname: nil, username: nil, password: nil, db: nil, reconnect_attempts: 1, **)
+                 fixed_hostname: nil, username: nil, password: nil, db: nil, reconnect_attempts: [0, 0.5, 1], **)
         return @client unless @client.nil?
 
         @pool_size = pool_size
@@ -31,10 +31,10 @@ module Legion
       end
 
       def build_redis_client(server: nil, servers: [], cluster: nil, replica: false, fixed_hostname: nil, # rubocop:disable Metrics/ParameterLists
-                             username: nil, password: nil, db: nil, reconnect_attempts: 1)
+                             username: nil, password: nil, db: nil, reconnect_attempts: [0, 0.5, 1])
         nodes = Array(cluster).compact
         if nodes.any?
-          opts = { cluster: nodes, reconnect_attempts: reconnect_attempts }
+          opts = { cluster: nodes, reconnect_attempts: reconnect_attempts, timeout: @timeout }
           opts[:replica] = true if replica
           opts[:fixed_hostname] = fixed_hostname unless fixed_hostname.nil?
           opts[:username] = username unless username.nil?
@@ -45,7 +45,8 @@ module Legion
             driver: 'redis', server: server, servers: servers
           )
           host, port = resolved.first.split(':')
-          redis_opts = { host: host, port: port.to_i, reconnect_attempts: reconnect_attempts }
+          redis_opts = { host: host, port: port.to_i, reconnect_attempts: reconnect_attempts,
+                         timeout: @timeout }
           redis_opts[:username] = username unless username.nil?
           redis_opts[:password] = password unless password.nil?
           redis_opts[:db] = db unless db.nil?

--- a/lib/legion/cache/settings.rb
+++ b/lib/legion/cache/settings.rb
@@ -33,7 +33,7 @@ module Legion
           username:           nil,
           password:           nil,
           db:                 nil,
-          reconnect_attempts: 1
+          reconnect_attempts: [0, 0.5, 1].freeze
         }
       end
 
@@ -56,7 +56,7 @@ module Legion
           username:           nil,
           password:           nil,
           db:                 nil,
-          reconnect_attempts: 1
+          reconnect_attempts: [0, 0.25, 0.5].freeze
         }
       end
 

--- a/lib/legion/cache/version.rb
+++ b/lib/legion/cache/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Cache
-    VERSION = '1.3.19'
+    VERSION = '1.3.20'
   end
 end


### PR DESCRIPTION
## Summary
- Forward `timeout` setting to `::Redis.new` in both standalone and cluster paths — was silently using redis gem's 1.0s default instead of configured 5s, causing spurious timeouts on service mesh connections
- Bump `reconnect_attempts` from `1` (instant, no backoff) to `[0, 0.5, 1]` (shared) / `[0, 0.25, 0.5]` (local) — 3 retries with escalating backoff delays

## Root Cause
`build_redis_client` passed `host`, `port`, `username`, `password`, `db`, and `reconnect_attempts` to `::Redis.new` but never `timeout`. The redis gem defaults to `DEFAULT_TIMEOUT = 1.0` for `connect_timeout`, `read_timeout`, and `write_timeout` when unset. On service mesh connections (Consul DNS resolution + TCP handshake + AUTH), 1.0s is insufficient — every reconnection attempt timed out, making it appear Redis never reconnected.

## Test plan
- [x] `bundle exec rspec` — 323 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses